### PR TITLE
Add missing fields to server responses

### DIFF
--- a/Sources/olleh/Commands/Serve.swift
+++ b/Sources/olleh/Commands/Serve.swift
@@ -52,6 +52,7 @@ private final actor OllamaServer: Sendable {
 
     private let jsonEncoder: JSONEncoder = {
         let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
         encoder.dateEncodingStrategy = .custom { date, encoder in
             let formatter = ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]


### PR DESCRIPTION
This PR adds the following fields to the final response to API requests:

- `totalDuration`: Measured actual time from start to finish
- `loadDuration`: Time taken to initialize and start the model request
- `promptEvalCount`: Approximate token count for input (prompt/messages)
- `promptEvalDuration`: Time taken for prompt evaluation (load time)
- `evalCount`: Approximate token count for generated response
- `evalDuration`: Time spent generating the response (total - load time)