### PR TITLE
Implement comprehensive server logging 

### DIFF
--- a/Sources/olleh/Commands/Serve.swift
+++ b/Sources/olleh/Commands/Serve.swift
@@ -213,15 +213,7 @@ private final actor OllamaServer: Sendable {
                             model: Model.ID(rawValue: model) ?? "default",
                             createdAt: Date(),
                             response: chunk,
-                            done: false,
-                            context: nil,
-                            thinking: nil,
-                            totalDuration: nil,
-                            loadDuration: nil,
-                            promptEvalCount: nil,
-                            promptEvalDuration: nil,
-                            evalCount: nil,
-                            evalDuration: nil
+                            done: false
                         )
 
                         let data = try self.jsonEncoder.encode(response)
@@ -272,15 +264,7 @@ private final actor OllamaServer: Sendable {
                         model: Model.ID(rawValue: model) ?? "default",
                         createdAt: Date(),
                         response: "Error: \(error.localizedDescription)",
-                        done: true,
-                        context: nil,
-                        thinking: nil,
-                        totalDuration: nil,
-                        loadDuration: nil,
-                        promptEvalCount: nil,
-                        promptEvalDuration: nil,
-                        evalCount: nil,
-                        evalDuration: nil
+                        done: true
                     )
 
                     let errorData = try self.jsonEncoder.encode(errorResponse)
@@ -474,13 +458,7 @@ private final actor OllamaServer: Sendable {
                         model: Model.ID(rawValue: model) ?? "default",
                         createdAt: Date(),
                         message: Chat.Message.assistant("Error: \(error.localizedDescription)"),
-                        done: true,
-                        totalDuration: nil,
-                        loadDuration: nil,
-                        promptEvalCount: nil,
-                        promptEvalDuration: nil,
-                        evalCount: nil,
-                        evalDuration: nil
+                        done: true
                     )
 
                     let errorData = try self.jsonEncoder.encode(errorResponse)


### PR DESCRIPTION
```
> olleh serve --verbose

2025-06-30T05:28:00-0700 debug olleh : sl-cancellationSignals=[] sl-gracefulShutdownSignals=[SIGTERM, SIGINT] sl-services=[Application] [ServiceLifecycle] Starting service lifecycle
2025-06-30T05:28:00-0700 debug olleh : sl-service=Application [ServiceLifecycle] Starting service
2025-06-30T05:28:00-0700 debug olleh : sl-cancellationSignals=[] sl-gracefulShutdownSignals=[] sl-services=[Hummingbird.DateCache, PreludeService<Server<HTTP1Channel>>] [ServiceLifecycle] Starting service lifecycle
2025-06-30T05:28:00-0700 debug olleh : sl-service=Hummingbird.DateCache [ServiceLifecycle] Starting service
2025-06-30T05:28:00-0700 debug olleh : sl-service=PreludeService<Server<HTTP1Channel>> [ServiceLifecycle] Starting service
2025-06-30T05:28:00-0700 info olleh : [HummingbirdCore] Server started and listening on 127.0.0.1:11941
2025-06-30T05:28:22-0700 info olleh : hb.request.id=fadf551858d3967a73886bf9ef4cc204 [olleh] POST /api/generate
2025-06-30T05:28:22-0700 debug olleh : hb.request.id=fadf551858d3967a73886bf9ef4cc204 model=default prompt_length=20 stream=true [olleh] Generate request
2025-06-30T05:28:26-0700 debug olleh : duration=4.10s hb.request.id=fadf551858d3967a73886bf9ef4cc204 tokens=230 [olleh] Generate streaming completed
```