### PR TITLE
Overhaul model information functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ SUBCOMMANDS:
   serve                   Start olleh
   run                     Run a model interactively
   list                    List models
+  show                    Show model information
   check                   Check availability
 
   See 'olleh help <subcommand>' for detailed help.

--- a/Sources/olleh/Commands/List.swift
+++ b/Sources/olleh/Commands/List.swift
@@ -16,8 +16,30 @@ extension Olleh {
 
             Task {
                 let models = await foundationModelsClient.listModels()
+
+                // Print header
+                print(
+                    "NAME".padding(toLength: 25, withPad: " ", startingAt: 0)
+                        + "ID".padding(toLength: 15, withPad: " ", startingAt: 0)
+                        + "SIZE".padding(toLength: 9, withPad: " ", startingAt: 0) + "MODIFIED")
+
+                // Print models
                 for model in models {
-                    print(model)
+                    let sizeStr =
+                        model.size > 0
+                        ? ByteCountFormatter.string(fromByteCount: model.size, countStyle: .file)
+                        : "N/A"
+                    let modifiedStr = RelativeDateTimeFormatter().localizedString(
+                        for: model.modifiedAt, relativeTo: Date())
+
+                    // Create a short digest for the ID column
+                    let shortDigest = String(model.digest.suffix(12))
+
+                    print(
+                        model.name.padding(toLength: 25, withPad: " ", startingAt: 0)
+                            + shortDigest.padding(toLength: 15, withPad: " ", startingAt: 0)
+                            + sizeStr.padding(toLength: 9, withPad: " ", startingAt: 0)
+                            + modifiedStr)
                 }
                 group.leave()
             }

--- a/Sources/olleh/Commands/Serve.swift
+++ b/Sources/olleh/Commands/Serve.swift
@@ -564,7 +564,7 @@ private final actor OllamaServer: Sendable {
                 parentModel: nil
             ),
             info: ["license": .string("Apple Foundation Models")],
-            capabilities: [.completion]
+            capabilities: [.completion, .tools]
         )
 
         let data = try jsonEncoder.encode(response)

--- a/Sources/olleh/Commands/Serve.swift
+++ b/Sources/olleh/Commands/Serve.swift
@@ -519,24 +519,17 @@ private final actor OllamaServer: Sendable {
         context.logger.debug("Listing available models")
         let models = await foundationModelsClient.listModels()
 
-        let response = Client.ListModelsResponse(
-            models: models.map {
-                Client.ListModelsResponse.Model(
-                    name: $0,
-                    modifiedAt: iso8601Formatter.string(from: Date()),
-                    size: 0,
-                    digest: "",
-                    details: Model.Details(
-                        format: "apple",
-                        family: "foundation",
-                        families: ["foundation"],
-                        parameterSize: "unknown",
-                        quantizationLevel: "unknown",
-                        parentModel: nil
-                    )
-                )
-            }
-        )
+        let listModels = models.map { modelInfo in
+            Client.ListModelsResponse.Model(
+                name: modelInfo.name,
+                modifiedAt: iso8601Formatter.string(from: modelInfo.modifiedAt),
+                size: modelInfo.size,
+                digest: modelInfo.digest,
+                details: modelInfo.details
+            )
+        }
+
+        let response = Client.ListModelsResponse(models: listModels)
 
         let data = try jsonEncoder.encode(response)
         return Response(
@@ -548,23 +541,32 @@ private final actor OllamaServer: Sendable {
 
     private func showModel(request: Request, context: some RequestContext) async throws -> Response
     {
-        let modelName = request.uri.queryParameters["name"] ?? "default"
+        guard let modelName = request.uri.queryParameters["name"]?.description else {
+            throw HTTPError(.badRequest, message: "Missing required parameter 'name'")
+        }
         context.logger.debug("Show model request", metadata: ["name": "\(modelName)"])
+
+        guard let modelInfo = await foundationModelsClient.getModelInfo(modelName) else {
+            throw HTTPError(.notFound, message: "Model '\(modelName)' not found")
+        }
+
+        var info: [String: Value] = [
+            "license": .string(modelInfo.license),
+            "architecture": .string(modelInfo.details.family),
+            "parameters": .string(modelInfo.details.parameterSize),
+            "context_length": .double(Double(modelInfo.contextLength)),
+            "embedding_length": .double(Double(modelInfo.embeddingLength)),
+        ]
+
+        info["temperature"] = .double(modelInfo.temperature)
 
         let response = Client.ShowModelResponse(
             modelfile: "FROM apple/foundation-models",
-            parameters: "{}",
+            parameters: info["temperature"]?.description ?? "0.7",
             template: "{{ .Prompt }}",
-            details: Model.Details(
-                format: "apple",
-                family: "foundation",
-                families: ["foundation"],
-                parameterSize: "unknown",
-                quantizationLevel: "unknown",
-                parentModel: nil
-            ),
-            info: ["license": .string("Apple Foundation Models")],
-            capabilities: [.completion, .tools]
+            details: modelInfo.details,
+            info: info,
+            capabilities: modelInfo.capabilities
         )
 
         let data = try jsonEncoder.encode(response)
@@ -574,5 +576,4 @@ private final actor OllamaServer: Sendable {
             body: .init(byteBuffer: ByteBuffer(data: data))
         )
     }
-
 }

--- a/Sources/olleh/main.swift
+++ b/Sources/olleh/main.swift
@@ -6,7 +6,7 @@ struct Olleh: ParsableCommand {
         commandName: "olleh",
         abstract: "Ollama-compatible CLI for Apple Foundation Models",
         version: "1.0.0",
-        subcommands: [Serve.self, Run.self, List.self, Check.self]
+        subcommands: [Serve.self, Run.self, List.self, Show.self, Check.self]
     )
 }
 


### PR DESCRIPTION
This PR adds a `show` subcommand, updates `list` to better match Ollama, and updates server endpoints accordingly. Apple Foundation Models details are also updated following the information provided [in this press release](https://machinelearning.apple.com/research/apple-foundation-models-2025-updates).